### PR TITLE
我发现了rustscan莫名其妙又修改了文件夹内的路径，变成嵌套tmp/xxxx了，我改了下json文件能用了,不知道他们下个版本会不会又改回来

### DIFF
--- a/bucket/RustScan.json
+++ b/bucket/RustScan.json
@@ -6,11 +6,11 @@
     "notes": "Scoop bucket for Cybersecurity by whoopscs(https://github.com/whoopscs/scoop-security).",
     "url": "https://github.com/RustScan/RustScan/releases/download/2.3.0/rustscan-2.3.0-x86_64-windows.zip",
     "hash": "3fcb9d5563bd0061fbdce49a06a2e423a4027494432775d9808638d3a4c4653f",
-    "extract_dir": "rustscan-2.3.0-x86_64-windows",
+    "extract_dir": "tmp\\rustscan-2.3.0-x86_64-windows",
     "bin": "rustscan.exe",
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/RustScan/RustScan/releases/download/$version/rustscan-$version-x86_64-windows.zip",
-        "extract_dir": "rustscan-$version-x86_64-windows"
+        "extract_dir": "tmp\\rustscan-$version-x86_64-windows"
     }
 }


### PR DESCRIPTION
大概就是这么个情况，不改解压文件找不到嵌套目录